### PR TITLE
[GITHUB-11] add quotation marks and jinja delimiters around bare variables

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,7 +22,7 @@
   shell: "bin/plugin install {{ item }}"
   args:
     chdir: "/opt/logstash"
-  with_items: logstash.plugins
+  with_items: "{{ logstash.plugins }}"
   notify:
     - restart logstash
 
@@ -31,7 +31,7 @@
   shell: "bin/plugin update --no-verify {{ item }}"
   args:
     chdir: "/opt/logstash"
-  with_items: logstash.plugins_update
+  with_items: "{{ logstash.plugins_update }}"
   notify:
     - restart logstash
 


### PR DESCRIPTION
In order to use this role with Ansible 2.2, any bare variables used as "with_items" in loops need to be quoted.
