### PR TITLE
Update users_and_groups dependency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,13 +9,16 @@ dependencies:
       - build
 
   - role: sansible.users_and_groups
-    version: v1.0
+    version: v1.4
     users_and_groups:
       groups:
         - name: "{{ logstash.group }}"
       users:
         - name: "{{ logstash.user }}"
           group: "{{ logstash.group }}"
+      sudoers: []
+      whitelist_groups: []
+      authorized_keys_dir:
     tags:
       - build
 


### PR DESCRIPTION
users_and_groups role v1.0 does not work anymore with Ansible 2.2.
Moreover, default variable values must be set.